### PR TITLE
Non-destructive translations

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -53,16 +53,23 @@ function showAbout() {
  * Sidebar title, content & size.
  *
  **/
-function translate(radioFull, radioSelected, sourceLangage, targetLangage) {
+function translate(radioFull, radioSelected, radioOgSheet, radioNewSheet, sourceLangage, targetLangage) {
     SpreadsheetApp.getActiveSpreadsheet().toast("Translation in progress...", "", -1);
     try {
         var activeSpreadsheet = SpreadsheetApp.getActiveSpreadsheet();
         var activeSheet = activeSpreadsheet.getActiveSheet();
+        var activeRange = activeSheet.getActiveRange().getA1Notation();
+        if (radioOgSheet) {
+			var targetSheet = activeSheet
+		} else if (radioNewSheet) {
+			var targetSheet = activeSpreadsheet.duplicateActiveSheet().setName(activeSheet.getName() + " - " + targetLangage);
+			targetSheet.setTabColor("1E824C");
+		}
         var activeCell = activeSheet.getActiveCell();
         if (radioFull) {
-            translateFullPage(activeSpreadsheet, sourceLangage, targetLangage);
+            translateFullPage(activeSpreadsheet, targetSheet, sourceLangage, targetLangage);
         } else if (radioSelected) {
-            translateSelectedCells(activeSpreadsheet, sourceLangage, targetLangage);
+            translateSelectedCells(activeSpreadsheet, targetSheet, activeRange, sourceLangage, targetLangage);
         }
         SpreadsheetApp.getActiveSpreadsheet().toast("Done.", "", 3);
     } catch (err) {
@@ -75,7 +82,7 @@ function translate(radioFull, radioSelected, sourceLangage, targetLangage) {
  * Code for translate full page content from a source to a target langage. 
  *
  **/
-function translateFullPage(activeSpreadsheet, sourceLangage, targetLangage) {
+function translateFullPage(activeSpreadsheet, targetSheet, sourceLangage, targetLangage) {
     var lrow = activeSpreadsheet.getLastRow();
     var lcol = activeSpreadsheet.getLastColumn();
     for (var i = 1; i <= lrow; i++) {
@@ -83,7 +90,7 @@ function translateFullPage(activeSpreadsheet, sourceLangage, targetLangage) {
             if (SpreadsheetApp.getActiveSpreadsheet().getActiveSheet().getRange(i, j).getValue() != "") {
                 var activeCellText = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet().getRange(i, j).getValue();
                 var activeCellTranslation = LanguageApp.translate(activeCellText, sourceLangage, targetLangage);
-                SpreadsheetApp.getActiveSpreadsheet().getActiveSheet().getRange(i, j).setValue(activeCellTranslation);
+                targetSheet.getRange(i, j).setValue(activeCellTranslation);
             }
         }
     }
@@ -94,8 +101,8 @@ function translateFullPage(activeSpreadsheet, sourceLangage, targetLangage) {
  * Code for translate only selected range content in a sheet from a source to a target langage. 
  *
  **/
-function translateSelectedCells(activeSpreadsheet, sourceLangage, targetLangage) {
-    var range = SpreadsheetApp.getActiveSheet().getActiveRange();
+function translateSelectedCells(activeSpreadsheet, targetSheet, activeRange, sourceLangage, targetLangage) {
+    var range = SpreadsheetApp.getActiveSheet().getRange(activeRange);
     var numRows = range.getNumRows();
     var numCols = range.getNumColumns();
     for (var i = 1; i <= numRows; i++) {
@@ -103,6 +110,8 @@ function translateSelectedCells(activeSpreadsheet, sourceLangage, targetLangage)
         var activeCellText = range.getCell(i,j).getValue();
         var activeCellTranslation = LanguageApp.translate(activeCellText, sourceLangage, targetLangage);
         range.getCell(i,j).setValue(activeCellTranslation);
+        range.getCell(i,j).setBackground("#1E824C");
+        range.getCell(i,j).setFontColor("#FFFFFF");
       }
     }
 }

--- a/index.html
+++ b/index.html
@@ -160,10 +160,16 @@
           </select>
      </div><br><br><br>
      <div class="inline form-group" align="left">
+		  <p><b>Chose which values you would like to have translated.</b></p>
           <label unselectable="on"><input type="radio" id="radioFull" name="translationType" value="full" /> Full sheet<br></label>
           <label unselectable="on"><input type="radio" id="radioSelected" name="translationType" value="selected" checked /> Selected range<br></label>
+          <p><b>Select where you would like the translations to be created.</b>
+          <br><br><b>'Original sheet'</b> will <b>overwrite</b> the original values with the translations.
+          <br><br><b>'New sheet'</b> will first create a duplicate work sheet and apply the translations there preserving the original.</p>
+          <label unselectable="on"><input type="radio" id="radioOgSheet" name="translationTarget" value="original" /> Original sheet<br></label>
+          <label unselectable="on"><input type="radio" id="radioNewSheet" name="translationTarget" value="new" checked /> New sheet<br></label>
      </div><br><br><br>
-     <button class="action" style="width:200px;height:40px" onclick="return google.script.run.translate(radioFull.checked, radioSelected.checked, sourceLanguage.options[sourceLanguage.selectedIndex].value, targetLanguage.options[targetLanguage.selectedIndex].value);">Translate</button>    
+     <button class="action" style="width:200px;height:40px" onclick="return google.script.run.translate(radioFull.checked, radioSelected.checked, radioOgSheet.checked, radioNewSheet.checked, sourceLanguage.options[sourceLanguage.selectedIndex].value, targetLanguage.options[targetLanguage.selectedIndex].value);">Translate</button>    
      <!-- Footer -->
      <div class="sidebar bottom" style="width:97%;">
          <img src="http://joeybronner.fr/translatemysheet/translatemysheetinlinemini.png" />


### PR DESCRIPTION
I thought it might be useful to create an option which would not replace the original text and instead create a new sheet for the translations.  This would be especially useful in the context of a domain or for a shared sheet.

Most of these changes accomplish that goal.  I also took the opportunity to clean up some of the multiple calls to the spreadsheet service which can potentially degrade performance on larger sheets and instead pass the objects from a single call between the functions.

Lastly, I added colouring to the newly created sheets and to specific range translations using the colours from your index file.  One thought though is that it might annoy end users if their source data is already pre-formatted.  If you agree, I can add an option for that as well before the pull.

All changes were tested in 'test as add-on' mode and worked as intended on my end, though you should probably re-test if you're planning on pulling these changes as I can see you have quite a few users for this add-on.